### PR TITLE
feat: 스크립트 생성 기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,9 @@ dependencies {
 
     // swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+
+    // OpenAI API 라이브러리
+    implementation 'com.theokanning.openai-gpt3-java:service:0.18.2'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -27,12 +27,15 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    compileOnly 'org.projectlombok:lombok'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
+    compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
 
     // DB
     runtimeOnly 'com.h2database:h2'

--- a/src/main/java/com/umc/owncast/common/response/status/ErrorCode.java
+++ b/src/main/java/com/umc/owncast/common/response/status/ErrorCode.java
@@ -25,6 +25,9 @@ public enum ErrorCode implements BaseErrorCode {
     MEMBER_SIGNUP_ERROR(HttpStatus.BAD_REQUEST, "SIGNUP4001", "회원가입 유효성 검사 실패"),
     EMAIL_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "SIGNUP4002", "이미 존재하는 이메일입니다."),
 
+    // 캐스트 관련 에러
+    REQUEST_TIMEOUT(HttpStatus.REQUEST_TIMEOUT, "CAST4001", "캐스트 생성시간이 너무 오래 걸립니다."),
+
     // 기타 에러는 아래에 추가
     ;
 

--- a/src/main/java/com/umc/owncast/domain/cast/controller/CastController.java
+++ b/src/main/java/com/umc/owncast/domain/cast/controller/CastController.java
@@ -1,0 +1,39 @@
+package com.umc.owncast.domain.cast.controller;
+
+import com.umc.owncast.common.response.ApiResponse;
+import com.umc.owncast.domain.cast.dto.CastCreationRequestDTO;
+import com.umc.owncast.domain.cast.service.CastService;
+import com.umc.owncast.domain.cast.service.ChatGPTScriptService;
+import com.umc.owncast.domain.cast.service.ScriptService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "캐스트 API", description = "캐스트 관련 API입니다")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/cast")
+public class CastController {
+    private final CastService castService;
+    private final ScriptService scriptService;
+
+    /* ScriptService 테스트 */
+    @PostMapping("/script")
+    @Operation(summary = "스크립트 생성 API (ScriptService 테스트용)")
+    public String createScript(@Valid @RequestBody CastCreationRequestDTO castRequest){
+        System.out.println(castRequest);
+        return scriptService.createScript(castRequest);
+    }
+
+    @PostMapping
+    public ApiResponse<Object> createCast(@Valid @RequestBody CastCreationRequestDTO castRequest){
+        return null;
+    }
+
+    @GetMapping("/raise-error")
+    public Object raiseError(){
+        throw new RuntimeException("에러 발생!");
+    }
+}

--- a/src/main/java/com/umc/owncast/domain/cast/controller/CastController.java
+++ b/src/main/java/com/umc/owncast/domain/cast/controller/CastController.java
@@ -5,11 +5,16 @@ import com.umc.owncast.domain.cast.dto.CastCreationRequestDTO;
 import com.umc.owncast.domain.cast.service.CastService;
 import com.umc.owncast.domain.cast.service.ChatGPTScriptService;
 import com.umc.owncast.domain.cast.service.ScriptService;
+import com.umc.owncast.domain.cast.service.StreamService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.web.bind.annotation.*;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
 
 @Tag(name = "캐스트 API", description = "캐스트 관련 API입니다")
 @RestController
@@ -18,6 +23,7 @@ import org.springframework.web.bind.annotation.*;
 public class CastController {
     private final CastService castService;
     private final ScriptService scriptService;
+    private final StreamService streamService;
 
     /* ScriptService 테스트 */
     @PostMapping("/script")
@@ -30,10 +36,5 @@ public class CastController {
     @PostMapping
     public ApiResponse<Object> createCast(@Valid @RequestBody CastCreationRequestDTO castRequest){
         return null;
-    }
-
-    @GetMapping("/raise-error")
-    public Object raiseError(){
-        throw new RuntimeException("에러 발생!");
     }
 }

--- a/src/main/java/com/umc/owncast/domain/cast/dto/CastCreationRequestDTO.java
+++ b/src/main/java/com/umc/owncast/domain/cast/dto/CastCreationRequestDTO.java
@@ -1,0 +1,26 @@
+package com.umc.owncast.domain.cast.dto;
+
+import com.umc.owncast.domain.enums.Formality;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+import lombok.*;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+public class CastCreationRequestDTO {
+    @NotEmpty(message = "키워드는 필수 입력 항목입니다.")
+    private String keyword;
+
+    private Formality formality = Formality.CASUAL;
+
+    private String voice = "DEFAULT_VOICE";
+
+    @Min(60)
+    @Max(600)
+    private int audioTime = 60;
+}

--- a/src/main/java/com/umc/owncast/domain/cast/entity/Cast.java
+++ b/src/main/java/com/umc/owncast/domain/cast/entity/Cast.java
@@ -29,7 +29,7 @@ public class Cast extends BaseTimeEntity {
     @Column(nullable = false)
     private Integer audioLength;
 
-    @Enumerated(EnumType.STRING)
+    @Column
     private String voice;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/umc/owncast/domain/cast/service/CastService.java
+++ b/src/main/java/com/umc/owncast/domain/cast/service/CastService.java
@@ -1,0 +1,19 @@
+package com.umc.owncast.domain.cast.service;
+
+
+import com.umc.owncast.common.response.ApiResponse;
+import com.umc.owncast.domain.cast.dto.CastCreationRequestDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CastService {
+    private final ScriptService scriptService;
+    // private final TTSService ttsService;
+    // private final StreamService streamService;
+
+    public ApiResponse<Object> createCast(CastCreationRequestDTO request){
+        return null;
+    }
+}

--- a/src/main/java/com/umc/owncast/domain/cast/service/ChatGPTPromptGenerator.java
+++ b/src/main/java/com/umc/owncast/domain/cast/service/ChatGPTPromptGenerator.java
@@ -1,0 +1,108 @@
+package com.umc.owncast.domain.cast.service;
+
+import com.theokanning.openai.completion.chat.ChatCompletionRequest;
+import com.theokanning.openai.completion.chat.ChatMessage;
+import com.theokanning.openai.completion.chat.ChatMessageRole;
+import com.umc.owncast.domain.enums.Formality;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+/* 사용자 입력 정보를 바탕으로 ChatGPT에 건넬 프롬프트를 생성 */
+public class ChatGPTPromptGenerator {
+
+    /* GPT 모델 : "gpt-4o" 혹은 "gpt-4o-mini" 중 선택 */
+    private final String DEFAULT_MODEL = "gpt-4o-mini";
+    
+    /* 문장을 뭘로 나눌지 */
+    private final String SENTENCE_DELIMITER = "@";
+    /**
+    * 스크립트 결정성 제어변수, 0~2 사이값
+    * 0에 가까울 수록 결정적인 답변을 얻음 (사실적)
+    * 2에 가까울 수록 랜덤하고 다양한 답변을 얻음 (아무말대잔치)
+    **/
+    private final double DEFAULT_TEMPERATURE = 0.1;
+
+    /* 사용자의 keyword를 바탕으로 프롬프트 생성 */
+    public ChatCompletionRequest generatePrompt(String keyword, Formality formality, int audioTime) {
+        return generatePrompt(keyword, formality, audioTime, DEFAULT_MODEL);
+    }
+
+    public ChatCompletionRequest generatePrompt(String keyword, Formality formality, int audioTime, String modelName) {
+        List<ChatMessage> promptMessage = createPromptMessage(keyword, formality, audioTime);
+
+        ChatCompletionRequest prompt = ChatCompletionRequest.builder()
+                .model(modelName)
+                .messages(promptMessage)
+                .temperature(DEFAULT_TEMPERATURE)
+                .build();
+
+        System.out.println("ChatGPTPromptGenerator - generated prompt:");
+        System.out.println(prompt);
+        return prompt;
+    }
+
+    public List<ChatMessage> createPromptMessage(String keyword, Formality formality, int audioTime) {
+        // 현재 사용자의 언어 설정에 맞춘다 TODO: 회원 기능으로 언어 설정 가져오기
+        String language = "English";
+        return createPromptMessage(keyword, formality, audioTime, language);
+    }
+
+    public List<ChatMessage> createPromptMessage(String keyword, Formality formality, int audioTime, String language) {
+        List<ChatMessage> systemPrompts;
+        List<ChatMessage> chatPrompts;
+
+        // 시스템 프롬프트
+        String system = ChatMessageRole.SYSTEM.value();
+        systemPrompts = List.of(
+                new ChatMessage(system, "You are the host of the podcast."), // 역할 부여
+                new ChatMessage(system, "Answer should only contain what you have to say (no markdowns or background musics)"), // 형식 지정
+                //new ChatMessage(system, "Answer should be less than " + tokens + " tokens"), // 분량 설정
+                //new ChatMessage(system, "Use around " + words + "words"), // 분량 설정 2   -->  (calculateWords() 개발 후 해보기)
+                new ChatMessage(system, "Answer should be " + audioTime/60 + " minutes long."), // 분량 설정 3
+                new ChatMessage(system, "You should add " + SENTENCE_DELIMITER + " at each end of sentences."), // 문장 분리
+                new ChatMessage(system, "Answer in " + formality.name() + " manner."), // 격식 설정 (official, casual)
+                new ChatMessage(system, "The answer should be in " + language.toLowerCase()) // 언어 설정 (English, Spanish, Japanese, ...)
+        );
+
+        // 채팅 메시지
+        String user = ChatMessageRole.USER.value();
+        String assistant = ChatMessageRole.ASSISTANT.value();
+        chatPrompts = List.of(
+                new ChatMessage(user, "Make a podcast script about " + keyword)
+        );
+
+        // 반환
+        List<ChatMessage> result = new ArrayList<>();
+        result.addAll(systemPrompts);
+        result.addAll(chatPrompts);
+        return result;
+    }
+
+    /** 분당 단어 수 기반으로 오디오 분량에 맞는 단어 수 어림계산 (아직 개발 X) */
+    private int calculateWords(int audioTime) {
+        // TODO: 언어 사투리 별로 WPM 나눠 계산
+        // WPM: Word Per Minute
+        final int ENGLISH_WPM = 150;
+        final int JAPANESE_WPM = 240;
+        final int SPANISH_WPM = 260;
+
+        final int WPM = 0;
+        // TODO: 사용자 언어 설정에 따라 WPM 결정
+        final String userLanguage = "TODO";
+        switch(userLanguage.toLowerCase()){
+            case "english":
+                break;
+            case "spanish":
+                break;
+            case "japanese":
+                break;
+            default:
+                break;
+        }
+        return WPM * (audioTime/60);
+    }
+
+}

--- a/src/main/java/com/umc/owncast/domain/cast/service/ChatGPTScriptGenerator.java
+++ b/src/main/java/com/umc/owncast/domain/cast/service/ChatGPTScriptGenerator.java
@@ -19,7 +19,7 @@ public class ChatGPTScriptGenerator {
 
     @PostConstruct
     public void init(){
-        openAiService = new OpenAiService(SECRET_KEY, Duration.ofSeconds(5));
+        openAiService = new OpenAiService(SECRET_KEY, Duration.ofSeconds(30)); // 30초 내에 응답 안올 시 예외 던짐
     }
 
     /**

--- a/src/main/java/com/umc/owncast/domain/cast/service/ChatGPTScriptGenerator.java
+++ b/src/main/java/com/umc/owncast/domain/cast/service/ChatGPTScriptGenerator.java
@@ -1,0 +1,37 @@
+package com.umc.owncast.domain.cast.service;
+
+
+import com.theokanning.openai.OpenAiHttpException;
+import com.theokanning.openai.completion.chat.*;
+import com.theokanning.openai.service.OpenAiService;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.net.SocketTimeoutException;
+import java.time.Duration;
+
+@Service
+public class ChatGPTScriptGenerator {
+    @Value("${open-ai.secret-key}")
+    private String SECRET_KEY;
+    private OpenAiService openAiService;
+
+    @PostConstruct
+    public void init(){
+        openAiService = new OpenAiService(SECRET_KEY, Duration.ofSeconds(5));
+    }
+
+    /**
+    * API를 요청해서 답변을 가져온다  <br>
+    * 프롬프트에 따라 여러가지 답변이 오게 만들 수도 있는데, <br>
+    * 이 경우 여러가지 Choice 중 첫 번째의 답변을 반환한다
+    * */
+    public String generateScript(ChatCompletionRequest request) {
+        ChatCompletionResult result = null;
+        result = openAiService.createChatCompletion(request); // OpenAiHttpException 발생 가능
+        // 첫 번째 Choice의 답변 반환
+        ChatCompletionChoice targetChoice = result.getChoices().get(0);
+        return targetChoice.getMessage().getContent();
+    }
+}

--- a/src/main/java/com/umc/owncast/domain/cast/service/ChatGPTScriptService.java
+++ b/src/main/java/com/umc/owncast/domain/cast/service/ChatGPTScriptService.java
@@ -1,0 +1,31 @@
+package com.umc.owncast.domain.cast.service;
+
+import com.theokanning.openai.completion.chat.ChatCompletionRequest;
+import com.umc.owncast.domain.cast.dto.CastCreationRequestDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class ChatGPTScriptService implements ScriptService{
+
+    private final ChatGPTPromptGenerator promptGenerator;
+    private final ChatGPTScriptGenerator scriptGenerator;
+
+    public String createScript(CastCreationRequestDTO castRequest) {
+        try {
+            ChatCompletionRequest prompt = promptGenerator.generatePrompt(
+                    castRequest.getKeyword(),
+                    castRequest.getFormality(),
+                    castRequest.getAudioTime()
+            );
+            return scriptGenerator.generateScript(prompt);
+        } catch(Exception e){
+            // 출력만 하고 전파 -> CastService에서 처리??
+            System.out.println("CastServiceImpl: Exception on createScript - " + e.getMessage());
+            System.out.println("Exception class : " + e.getClass());
+            System.out.println("Exception cause : " + e.getCause());
+            throw e;
+        }
+    }
+}

--- a/src/main/java/com/umc/owncast/domain/cast/service/ScriptService.java
+++ b/src/main/java/com/umc/owncast/domain/cast/service/ScriptService.java
@@ -1,0 +1,10 @@
+package com.umc.owncast.domain.cast.service;
+
+import com.umc.owncast.common.response.ApiResponse;
+import com.umc.owncast.domain.cast.dto.CastCreationRequestDTO;
+import org.springframework.stereotype.Service;
+
+@Service
+public interface ScriptService {
+    public String createScript(CastCreationRequestDTO request);
+}


### PR DESCRIPTION
`openai-java` 라이브러리 가져와서 구현했습니다 
(https://github.com/TheoKanning/openai-java)

# CastService 구조
![스크린샷 2024-07-27 173856](https://github.com/user-attachments/assets/6bb5679c-f732-4886-87df-78137bc79a02)
요런 느낌으로 갈 것 같습니다
이번 PR은 `ScriptService`까지 완성

# CastCreationDTO
사용자가 요청하는 데이터입니다
캐스트 생성에 필요한 정보를 담습니다
(keyword, formality, voice, audioTime...)

# ChatGPTPromptGenerator
`CastCreationDTO`를 받아서, 적절한 답변을 하도록 `ChatCompletionRequest`를 반환합니다
`createPromptMessage()` 메소드 위주로 봐주시고 나머지는 주석 정도만 읽으면 될 것 같습니다

# ChatGPTScriptGenerator
`ChatCompletionRequest`를 받아서 OpenAI에 API 요청을 날립니다
API 요청 오류 시 `OpenAiHttpException`이나 그 외 경우 `RuntimeException`을 던질 수 있는데, 아직 예외처리는 안돼있습니다
(CastService 완성할 때 그 쪽에서 처리할 예정)

### Todo (나중에 할 일)
---
- 예외처리
- 사용자 언어 설정에 맞춰 캐스트 생성 -> 현재 사용자 정보 가져오는 기능 만들어지면 구현
  - 지금은 영어를 디폴트로 생성하도록 되어있음
- 언어 별로 오디오 길이에 맞는 분량 캐스트 생성
  - 지금은 주먹구구식으로 'n분 분량에 맞게 생성해줘' 식으로 요구하는데, 잘 지켜지지 않음
  - 단어나 토큰 수를 제한하는 방식으로 해야할 듯
