### PR TITLE
feat: 외부 API 실행시간 추적

### DIFF
--- a/src/main/java/com/umc/owncast/domain/cast/service/TTSService.java
+++ b/src/main/java/com/umc/owncast/domain/cast/service/TTSService.java
@@ -58,10 +58,14 @@ public class TTSService {
         audioConfig.put("audioEncoding", "MP3");
         requestBody.put("audioConfig", audioConfig);
 
+
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
         HttpEntity<Map<String, Object>> entity = new HttpEntity<>(requestBody, headers);
+        Long startTime = System.currentTimeMillis();
         ResponseEntity<Map> response = restTemplate.exchange(url, HttpMethod.POST, entity, Map.class);
+        Long endTime = System.currentTimeMillis();
+        System.out.printf("TTSService: TTS took %.2f seconds%n", (double)(endTime - startTime)/1000);
         String audioContent = (String) response.getBody().get("audioContent");
 
         List<Map<String, Object>> timepoints = (List<Map<String, Object>>) response.getBody().get("timepoints");

--- a/src/main/java/com/umc/owncast/domain/cast/service/chatGPT/ChatGPTAnswerGenerator.java
+++ b/src/main/java/com/umc/owncast/domain/cast/service/chatGPT/ChatGPTAnswerGenerator.java
@@ -27,10 +27,14 @@ public class ChatGPTAnswerGenerator {
      * 이 경우 여러가지 Choice 중 첫 번째의 답변을 반환한다
      */
     public String generateAnswer(ChatCompletionRequest request) {
+        Long startTime = System.currentTimeMillis();
         ChatCompletionResult result = null;
         result = openAiService.createChatCompletion(request); // OpenAiHttpException 발생 가능
+        Long endTime = System.currentTimeMillis();
         // 첫 번째 Choice의 답변 반환
         ChatCompletionChoice targetChoice = result.getChoices().get(0);
+        System.out.printf("ChatGPTAnswerGenerator: generation took %.2f seconds, consumed %d tokens total (prompt %d, completion %d)%n"
+                , (double)(endTime - startTime)/1000, result.getUsage().getTotalTokens(), result.getUsage().getPromptTokens(), result.getUsage().getCompletionTokens());
         return targetChoice.getMessage().getContent();
     }
 }

--- a/src/main/java/com/umc/owncast/domain/sentence/service/TranslateService.java
+++ b/src/main/java/com/umc/owncast/domain/sentence/service/TranslateService.java
@@ -33,7 +33,10 @@ public class TranslateService {
         requestHeaders.put("X-NCP-APIGW-API-KEY-ID", clientId);
         requestHeaders.put("X-NCP-APIGW-API-KEY", clientSecret);
 
+        long startTime = System.currentTimeMillis();
         String responseBody = post(requestHeaders, text);
+        long endTime = System.currentTimeMillis();
+        System.out.printf("PapagoTranslationService: Translation took %.2f seconds%n", (double)(endTime - startTime)/1000);
         JSONObject jsonObject = new JSONObject(responseBody);
 
         String translatedText = jsonObject.getJSONObject("message").getJSONObject("result").getString("translatedText");


### PR DESCRIPTION
ChatGPT / TTS / Papago 요 외부 API 3개 방문하는 코드 실행시간 콘솔에 출력하게 바꿨습니다
- 일단 콘솔에 출력하는데,, 나중에 logger 쓰도록 바꿔도 될 듯

*(closes #64)*