### PR TITLE
update: 스크립트 번역 개선

### DIFF
--- a/src/main/java/com/umc/owncast/domain/cast/service/chatGPT/ChatGptAnswerGenerator.java
+++ b/src/main/java/com/umc/owncast/domain/cast/service/chatGPT/ChatGptAnswerGenerator.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Service;
 import java.time.Duration;
 
 @Service
-public class ChatGPTAnswerGenerator {
+public class ChatGptAnswerGenerator {
     @Value("${open-ai.secret-key}")
     private String SECRET_KEY;
     private OpenAiService openAiService;

--- a/src/main/java/com/umc/owncast/domain/cast/service/chatGPT/ChatGptPromptGenerator.java
+++ b/src/main/java/com/umc/owncast/domain/cast/service/chatGPT/ChatGptPromptGenerator.java
@@ -11,7 +11,7 @@ import java.util.List;
 
 @Service
 /* 사용자 입력 정보를 바탕으로 ChatGPT에 건넬 프롬프트를 생성 */
-public class ChatGPTPromptGenerator {
+public class ChatGptPromptGenerator {
 
     /* GPT 모델 : "gpt-4o" 혹은 "gpt-4o-mini" 중 선택 */
     private final String DEFAULT_MODEL = "gpt-4o-mini";
@@ -39,7 +39,7 @@ public class ChatGPTPromptGenerator {
                 .temperature(DEFAULT_TEMPERATURE)
                 .build();
 
-        System.out.println("ChatGPTPromptGenerator - generated prompt:");
+        System.out.println("ChatGptPromptGenerator - generated prompt:");
         System.out.println(prompt);
         return prompt;
     }
@@ -120,7 +120,7 @@ public class ChatGPTPromptGenerator {
                 .temperature(DEFAULT_TEMPERATURE)
                 .build();
 
-        System.out.println("ChatGPTPromptGenerator - generated prompt:");
+        System.out.println("ChatGptPromptGenerator - generated prompt:");
         System.out.println(prompt);
         return prompt;
     }

--- a/src/main/java/com/umc/owncast/domain/cast/service/chatGPT/keyword/KeywordServiceImpl.java
+++ b/src/main/java/com/umc/owncast/domain/cast/service/chatGPT/keyword/KeywordServiceImpl.java
@@ -5,8 +5,8 @@ import com.google.gson.reflect.TypeToken;
 import com.theokanning.openai.completion.chat.ChatCompletionRequest;
 import com.umc.owncast.common.exception.handler.UserHandler;
 import com.umc.owncast.common.response.status.ErrorCode;
-import com.umc.owncast.domain.cast.service.chatGPT.ChatGPTAnswerGenerator;
-import com.umc.owncast.domain.cast.service.chatGPT.ChatGPTPromptGenerator;
+import com.umc.owncast.domain.cast.service.chatGPT.ChatGptAnswerGenerator;
+import com.umc.owncast.domain.cast.service.chatGPT.ChatGptPromptGenerator;
 import com.umc.owncast.domain.category.repository.MainCategoryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -19,8 +19,8 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class KeywordServiceImpl implements KeywordService {
 
-    private final ChatGPTPromptGenerator chatGPTPromptGenerator;
-    private final ChatGPTAnswerGenerator answerGenerator;
+    private final ChatGptPromptGenerator chatGPTPromptGenerator;
+    private final ChatGptAnswerGenerator answerGenerator;
     private final MainCategoryRepository mainCategoryRepository;
 
     @Override

--- a/src/main/java/com/umc/owncast/domain/cast/service/chatGPT/script/ChatGptScriptService.java
+++ b/src/main/java/com/umc/owncast/domain/cast/service/chatGPT/script/ChatGptScriptService.java
@@ -4,6 +4,7 @@ import com.theokanning.openai.completion.chat.ChatCompletionRequest;
 import com.umc.owncast.domain.cast.dto.KeywordCastCreationDTO;
 import com.umc.owncast.domain.cast.service.chatGPT.ChatGptAnswerGenerator;
 import com.umc.owncast.domain.cast.service.chatGPT.ChatGptPromptGenerator;
+import com.umc.owncast.domain.sentence.service.TranslationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -13,10 +14,13 @@ public class ChatGptScriptService implements ScriptService {
 
     private final ChatGptPromptGenerator promptGenerator;
     private final ChatGptAnswerGenerator answerGenerator;
+    private final TranslationService translationService;
 
     public String createScript(KeywordCastCreationDTO castRequest) {
         String script = "";
         try {
+            String translatedKeyword = translationService.translateToMemberLanguage(castRequest.getKeyword());
+            castRequest.setKeyword(translatedKeyword);
             ChatCompletionRequest prompt = promptGenerator.generatePrompt(
                     castRequest.getKeyword(),
                     castRequest.getFormality(),

--- a/src/main/java/com/umc/owncast/domain/cast/service/chatGPT/script/ChatGptScriptService.java
+++ b/src/main/java/com/umc/owncast/domain/cast/service/chatGPT/script/ChatGptScriptService.java
@@ -2,17 +2,17 @@ package com.umc.owncast.domain.cast.service.chatGPT.script;
 
 import com.theokanning.openai.completion.chat.ChatCompletionRequest;
 import com.umc.owncast.domain.cast.dto.KeywordCastCreationDTO;
-import com.umc.owncast.domain.cast.service.chatGPT.ChatGPTAnswerGenerator;
-import com.umc.owncast.domain.cast.service.chatGPT.ChatGPTPromptGenerator;
+import com.umc.owncast.domain.cast.service.chatGPT.ChatGptAnswerGenerator;
+import com.umc.owncast.domain.cast.service.chatGPT.ChatGptPromptGenerator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
 @Service
-public class ChatGPTScriptService implements ScriptService {
+public class ChatGptScriptService implements ScriptService {
 
-    private final ChatGPTPromptGenerator promptGenerator;
-    private final ChatGPTAnswerGenerator answerGenerator;
+    private final ChatGptPromptGenerator promptGenerator;
+    private final ChatGptAnswerGenerator answerGenerator;
 
     public String createScript(KeywordCastCreationDTO castRequest) {
         String script = "";

--- a/src/main/java/com/umc/owncast/domain/sentence/service/ChatGptTranslationService.java
+++ b/src/main/java/com/umc/owncast/domain/sentence/service/ChatGptTranslationService.java
@@ -33,8 +33,10 @@ public class ChatGptTranslationService implements TranslationService{
     public String translate(String script) {
         List<ChatMessage> systemPrompt = List.of(
                 new ChatMessage(SYSTEM, "You are a translator which translates given script to korean."),
-                new ChatMessage(SYSTEM, "Translation result should look natural"),
+                new ChatMessage(SYSTEM, "Translation result should look natural."),
+                new ChatMessage(SYSTEM, "The number of sentences of the translation result should be EQUAL to the original script."),
                 new ChatMessage(SYSTEM, "'@' means end of the sentence; you should leave it be.")
+
         );
 
         List<ChatMessage> chatPrompt = List.of(

--- a/src/main/java/com/umc/owncast/domain/sentence/service/ChatGptTranslationService.java
+++ b/src/main/java/com/umc/owncast/domain/sentence/service/ChatGptTranslationService.java
@@ -41,7 +41,9 @@ public class ChatGptTranslationService implements TranslationService{
 
         List<ChatMessage> chatPrompt = List.of(
                 new ChatMessage(USER, "Welcome to today's episode of our financial news podcast, where we delve into the latest developments in the S&P 500. "),
-                new ChatMessage(ASSISTANT, "오늘의 팟캐스트에 오신 걸 환영합니다, 오늘은 가장 최근의 S&P 500 근황에 대해 알아보겠습니다."),
+                new ChatMessage(ASSISTANT, "오늘의 팟캐스트에 오신 걸 환영합니다 - 오늘은 가장 최근의 S&P 500 근황에 대해 알아보겠습니다."),
+                new ChatMessage(USER, "Welcome to today's episode of our podcast, where we explore the vibrant world of higher education institutions around the globe. "),
+                new ChatMessage(ASSISTANT, "오늘의 팟캐스트에 오신 것을 환영합니다, 오늘은 전 세계 고등 교육 기관의 활기찬 세계를 탐구해 보겠습니다."),
                 new ChatMessage(USER, "A Farewell To Arms"),
                 new ChatMessage(ASSISTANT, "무기여 잘 있거라"),
                 new ChatMessage(USER, "Welcome, This is a test script! @ Thank you! @"),

--- a/src/main/java/com/umc/owncast/domain/sentence/service/ChatGptTranslationService.java
+++ b/src/main/java/com/umc/owncast/domain/sentence/service/ChatGptTranslationService.java
@@ -1,0 +1,74 @@
+package com.umc.owncast.domain.sentence.service;
+
+import com.theokanning.openai.completion.chat.ChatCompletionRequest;
+import com.theokanning.openai.completion.chat.ChatCompletionResult;
+import com.theokanning.openai.completion.chat.ChatMessage;
+import com.theokanning.openai.completion.chat.ChatMessageRole;
+import com.theokanning.openai.service.OpenAiService;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class ChatGptTranslationService implements TranslationService{
+    @Value("${open-ai.secret-key}")
+    private String SECRET_KEY;
+    private OpenAiService openAiService;
+
+    private final String USER = ChatMessageRole.USER.value();
+    private final String ASSISTANT = ChatMessageRole.ASSISTANT.value();
+    private final String SYSTEM = ChatMessageRole.SYSTEM.value();
+
+    @PostConstruct
+    public void init() {
+        openAiService = new OpenAiService(SECRET_KEY, Duration.ofSeconds(30)); // 30초 내에 응답 안올 시 예외 던짐
+        // TODO openAiService 싱글톤으로 (OpenAiServiceWrapper 빈으로 감싸서 클래스 이곳 저곳에 제공?)
+    }
+
+    @Override
+    public String translate(String script) {
+        List<ChatMessage> systemPrompt = List.of(
+                new ChatMessage(SYSTEM, "You are a translator which translates given script to korean."),
+                new ChatMessage(SYSTEM, "Translation result should look natural"),
+                new ChatMessage(SYSTEM, "'@' means end of the sentence; you should leave it be.")
+        );
+
+        List<ChatMessage> chatPrompt = List.of(
+                new ChatMessage(USER, "Welcome to today's episode of our financial news podcast, where we delve into the latest developments in the S&P 500. "),
+                new ChatMessage(ASSISTANT, "오늘의 팟캐스트에 오신 걸 환영합니다, 오늘은 가장 최근의 S&P 500 근황에 대해 알아보겠습니다."),
+                new ChatMessage(USER, "A Farewell To Arms"),
+                new ChatMessage(ASSISTANT, "무기여 잘 있거라"),
+                new ChatMessage(USER, "Welcome, This is a test script! @ Thank you! @"),
+                new ChatMessage(ASSISTANT, "환영합니다, 이건 테스트용 스크립트에요! @ 감사합니다! @"),
+                new ChatMessage(USER, script)
+        );
+
+        return getOpenAiResult(generatePrompt(systemPrompt, chatPrompt));
+    }
+
+    private ChatCompletionRequest generatePrompt(List<ChatMessage> systemPrompt, List<ChatMessage> chatPrompt){
+        List<ChatMessage> promptMessage = new ArrayList<>();
+        promptMessage.addAll(systemPrompt);
+        promptMessage.addAll(chatPrompt);
+
+        return ChatCompletionRequest.builder()
+                .model("gpt-4o-mini")
+                .messages(promptMessage)
+                .temperature(0.2)
+                .build();
+    }
+
+    private String getOpenAiResult(ChatCompletionRequest request){
+        Long startTime = System.currentTimeMillis();
+        ChatCompletionResult result = openAiService.createChatCompletion(request);
+        Long endTime = System.currentTimeMillis();
+        System.out.printf("GPTTranslationService: chat took %d seconds, and consumed %d tokens total (prompt %d, completion %d)%n", (endTime-startTime)/1000, result.getUsage().getTotalTokens(), result.getUsage().getPromptTokens(), result.getUsage().getCompletionTokens());
+        return result.getChoices().get(0).getMessage().getContent();
+    }
+
+
+}

--- a/src/main/java/com/umc/owncast/domain/sentence/service/ChatGptTranslationService.java
+++ b/src/main/java/com/umc/owncast/domain/sentence/service/ChatGptTranslationService.java
@@ -66,7 +66,7 @@ public class ChatGptTranslationService implements TranslationService{
         Long startTime = System.currentTimeMillis();
         ChatCompletionResult result = openAiService.createChatCompletion(request);
         Long endTime = System.currentTimeMillis();
-        System.out.printf("GPTTranslationService: chat took %d seconds, and consumed %d tokens total (prompt %d, completion %d)%n", (endTime-startTime)/1000, result.getUsage().getTotalTokens(), result.getUsage().getPromptTokens(), result.getUsage().getCompletionTokens());
+        System.out.printf("GPTTranslationService: translation took %d seconds, consumed %d tokens total (prompt %d, completion %d)%n", (endTime-startTime)/1000, result.getUsage().getTotalTokens(), result.getUsage().getPromptTokens(), result.getUsage().getCompletionTokens());
         return result.getChoices().get(0).getMessage().getContent();
     }
 

--- a/src/main/java/com/umc/owncast/domain/sentence/service/ChatGptTranslationService.java
+++ b/src/main/java/com/umc/owncast/domain/sentence/service/ChatGptTranslationService.java
@@ -30,7 +30,7 @@ public class ChatGptTranslationService implements TranslationService{
     }
 
     @Override
-    public String translate(String script) {
+    public String translateToKorean(String script) {
         List<ChatMessage> systemPrompt = List.of(
                 new ChatMessage(SYSTEM, "You are a translator which translates given script to korean."),
                 new ChatMessage(SYSTEM, "Translation result should look natural."),
@@ -46,6 +46,38 @@ public class ChatGptTranslationService implements TranslationService{
                 new ChatMessage(ASSISTANT, "무기여 잘 있거라"),
                 new ChatMessage(USER, "Welcome, This is a test script! @ Thank you! @"),
                 new ChatMessage(ASSISTANT, "환영합니다, 이건 테스트용 스크립트에요! @ 감사합니다! @"),
+                new ChatMessage(USER, script)
+        );
+
+        return getOpenAiResult(generatePrompt(systemPrompt, chatPrompt));
+    }
+
+    @Override
+    public String translateToMemberLanguage(String script) {
+        String memberLanguage = "english";
+
+        List<ChatMessage> systemPrompt = List.of(
+                new ChatMessage(SYSTEM, "You are a translator which translates given script to " + memberLanguage), // TODO 회원 기능 연동
+                new ChatMessage(SYSTEM, "Translation result should look natural."),
+                new ChatMessage(SYSTEM, "The number of sentences of the translation result should be EQUAL to the original script."),
+                new ChatMessage(SYSTEM, "'@' means end of the sentence; you should leave it be.")
+
+        );
+
+        // TODO 언어에 따라 프롬프트 조정?
+        List<ChatMessage> chatPrompt = List.of(
+                new ChatMessage(USER, "오늘의 팟캐스트에 오신 걸 환영합니다, 오늘은 가장 최근의 S&P 500 근황에 대해 알아보겠습니다."),
+                new ChatMessage(ASSISTANT, "Welcome to today's episode of our financial news podcast, where we delve into the latest developments in the S&P 500. "),
+                new ChatMessage(USER, "무기여 잘 있거라"),
+                new ChatMessage(ASSISTANT, "A Farewell To Arms"),
+                new ChatMessage(USER, "올림픽"),
+                new ChatMessage(ASSISTANT, "オリンピック"),
+                new ChatMessage(USER, "최근 자바스크립트 근황"),
+                new ChatMessage(ASSISTANT, "Recent JavaScript updates"),
+                new ChatMessage(USER, "coffee"),
+                new ChatMessage(ASSISTANT, "coffee"),
+                new ChatMessage(USER, "커피 맛있게 마시는 법"),
+                new ChatMessage(ASSISTANT, "Cómo disfrutar del café"),
                 new ChatMessage(USER, script)
         );
 

--- a/src/main/java/com/umc/owncast/domain/sentence/service/PapagoTranslationService.java
+++ b/src/main/java/com/umc/owncast/domain/sentence/service/PapagoTranslationService.java
@@ -20,7 +20,7 @@ public class PapagoTranslationService implements TranslationService{
     String secret;
 
     @Override
-    public String translate(String script) {
+    public String translateToKorean(String script) {
         String clientId = id;
         String clientSecret = secret;
         String text;
@@ -43,6 +43,11 @@ public class PapagoTranslationService implements TranslationService{
         String translatedText = jsonObject.getJSONObject("message").getJSONObject("result").getString("translatedText");
         System.out.println(translatedText);
         return translatedText;
+    }
+
+    @Override
+    public String translateToMemberLanguage(String script) {
+        return null;
     }
 
     private static String post(Map<String, String> requestHeaders, String text) {

--- a/src/main/java/com/umc/owncast/domain/sentence/service/PapagoTranslationService.java
+++ b/src/main/java/com/umc/owncast/domain/sentence/service/PapagoTranslationService.java
@@ -12,7 +12,7 @@ import java.net.URLEncoder;
 import java.util.HashMap;
 import java.util.Map;
 
-@Service
+//@Service
 public class PapagoTranslationService implements TranslationService{
     @Value("${naver.cloud.id}")
     String id;

--- a/src/main/java/com/umc/owncast/domain/sentence/service/PapagoTranslationService.java
+++ b/src/main/java/com/umc/owncast/domain/sentence/service/PapagoTranslationService.java
@@ -13,7 +13,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 @Service
-public class TranslateService {
+public class PapagoTranslationService implements TranslationService{
     @Value("${naver.cloud.id}")
     String id;
     @Value("${naver.cloud.secret}")

--- a/src/main/java/com/umc/owncast/domain/sentence/service/PapagoTranslationService.java
+++ b/src/main/java/com/umc/owncast/domain/sentence/service/PapagoTranslationService.java
@@ -19,6 +19,7 @@ public class PapagoTranslationService implements TranslationService{
     @Value("${naver.cloud.secret}")
     String secret;
 
+    @Override
     public String translate(String script) {
         String clientId = id;
         String clientSecret = secret;

--- a/src/main/java/com/umc/owncast/domain/sentence/service/SentenceServiceImpl.java
+++ b/src/main/java/com/umc/owncast/domain/sentence/service/SentenceServiceImpl.java
@@ -24,7 +24,7 @@ public class SentenceServiceImpl implements SentenceService {
     @Override
     public List<Sentence> save(String original, TTSResultDTO ttsResultDTO, Cast cast) {
         int i = 0;
-        String koreanScript = translationService.translate(original);
+        String koreanScript = translationService.translateToKorean(original);
         String[] originalList = parsingService.parseSentences(original);
         String[] koreanList = parsingService.parseSentences(koreanScript);
         List<Sentence> sentences = new ArrayList<>();

--- a/src/main/java/com/umc/owncast/domain/sentence/service/SentenceServiceImpl.java
+++ b/src/main/java/com/umc/owncast/domain/sentence/service/SentenceServiceImpl.java
@@ -17,14 +17,14 @@ import java.util.List;
 @RequiredArgsConstructor
 public class SentenceServiceImpl implements SentenceService {
 
-    private final TranslateService translateService;
+    private final TranslationService translationService;
     private final SentenceRepository sentenceRepository;
     private final ParsingService parsingService;
 
     @Override
     public List<Sentence> save(String original, TTSResultDTO ttsResultDTO, Cast cast) {
         int i = 0;
-        String koreanScript = translateService.translate(original);
+        String koreanScript = translationService.translate(original);
         String[] originalList = parsingService.parseSentences(original);
         String[] koreanList = parsingService.parseSentences(koreanScript);
         List<Sentence> sentences = new ArrayList<>();

--- a/src/main/java/com/umc/owncast/domain/sentence/service/TranslationService.java
+++ b/src/main/java/com/umc/owncast/domain/sentence/service/TranslationService.java
@@ -5,5 +5,6 @@ import org.springframework.stereotype.Service;
 @Service
 public interface TranslationService {
     /** script 한국어로 번역 */
-    String translate(String script);
+    String translateToKorean(String script);
+    String translateToMemberLanguage(String script);
 }

--- a/src/main/java/com/umc/owncast/domain/sentence/service/TranslationService.java
+++ b/src/main/java/com/umc/owncast/domain/sentence/service/TranslationService.java
@@ -4,5 +4,6 @@ import org.springframework.stereotype.Service;
 
 @Service
 public interface TranslationService {
+    /** script 한국어로 번역 */
     public String translate(String script);
 }

--- a/src/main/java/com/umc/owncast/domain/sentence/service/TranslationService.java
+++ b/src/main/java/com/umc/owncast/domain/sentence/service/TranslationService.java
@@ -5,5 +5,5 @@ import org.springframework.stereotype.Service;
 @Service
 public interface TranslationService {
     /** script 한국어로 번역 */
-    public String translate(String script);
+    String translate(String script);
 }

--- a/src/main/java/com/umc/owncast/domain/sentence/service/TranslationService.java
+++ b/src/main/java/com/umc/owncast/domain/sentence/service/TranslationService.java
@@ -1,0 +1,8 @@
+package com.umc.owncast.domain.sentence.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public interface TranslationService {
+    public String translate(String script);
+}


### PR DESCRIPTION
이슈 #41 번 참고해주시면 좋을 것 같습니다
파파고로  번역하니까 어투가 매번 달라지는 이슈가 있어서 ChatGPT한테 맡겼습니다
시간은 조금 더 소요되긴 하는데 훨씬 자연스러워요 (#63 코멘트 참고)

## 변경점
**TranslationService**
- 인터페이스로 바꿨습니다

**PapagoTranslationService (구 TranslationService)**
- 예전에 `TranslationService`였던 클래스입니다
  새로 만든 `TranslationService` 인터페이스의 구현체로 남겨뒀습니다
  (코드는 언젠가 쓸 수도 있으므로)

**ChatGptTranslationService**
- 새로 만든 클래스입니다
ChatGPT API로 번역을 담당합니다
- 마찬가지로 `TranslationService`의 구현체고,
현재는 얘를 빈으로 등록해놔서 번역할 때 이 클래스가 쓰입니다

(*closes #63, #41*)