### PR TITLE
fix: 번역 프롬프트 수정

### DIFF
--- a/src/main/java/com/umc/owncast/domain/sentence/service/ChatGptTranslationService.java
+++ b/src/main/java/com/umc/owncast/domain/sentence/service/ChatGptTranslationService.java
@@ -36,7 +36,8 @@ public class ChatGptTranslationService implements TranslationService{
         List<ChatMessage> systemPrompt = List.of(
                 new ChatMessage(SYSTEM, "You are a translator which translates given script to korean."),
                 new ChatMessage(SYSTEM, "Translate the input, sentence by sentence."),
-                new ChatMessage(SYSTEM, "Each sentence in output should correspond with each sentences in input.")
+//                new ChatMessage(SYSTEM, "Each sentence in output should correspond with each sentences in input.")
+                new ChatMessage(SYSTEM, "'@' is a sentence seperator, so leave it be; never touch it.")
         );
 
         List<ChatMessage> chatPrompt = List.of(


### PR DESCRIPTION
- 필요없는 프롬프트 삭제했고 문장 구분자 놔두도록 얘기함
- 번역 쪽 `IndexError`가 나길래 바꿨습니다