### PR TITLE
fix: 키워드 캐스트 생성도 ScriptDivider 거치도록 변경

### DIFF
--- a/src/main/java/com/umc/owncast/domain/cast/service/CastServiceImpl.java
+++ b/src/main/java/com/umc/owncast/domain/cast/service/CastServiceImpl.java
@@ -57,7 +57,9 @@ public class CastServiceImpl implements CastService {
     @Override
     public CastScriptDTO createCastByKeyword(KeywordCastCreationDTO castRequest, Member member) {
         String script = scriptService.createScript(member, castRequest);
-        return handleCastCreation(castRequest, script, member);
+        String dividedScript = scriptDivider.placeDelimiter(script, "@");
+//        return handleCastCreation(castRequest, script, member);
+        return handleCastCreation(castRequest, dividedScript, member);
     }
 
     @Override

--- a/src/main/java/com/umc/owncast/domain/cast/service/chatGPT/ChatGptPromptGenerator.java
+++ b/src/main/java/com/umc/owncast/domain/cast/service/chatGPT/ChatGptPromptGenerator.java
@@ -66,7 +66,7 @@ public class ChatGptPromptGenerator {
                 new ChatMessage(SYSTEM, "You are the host of the podcast, named 'OwncastBot'"),
                 new ChatMessage(SYSTEM, "Your job is to write a podcast script about what happened recently; Write it based on real news."),
                 new ChatMessage(SYSTEM, "Script should only contain what you have to say (no markdowns or background musics)"),
-                new ChatMessage(SYSTEM, "Seperate each sentence using '@'."),
+//                new ChatMessage(SYSTEM, "Seperate each sentence using '@'."),
                 new ChatMessage(SYSTEM, "Answer in " + formality.name().toLowerCase() + " manner."),
                 new ChatMessage(SYSTEM, "Answer in " + member.getLanguage().getRealLanguage() + ".")
         );


### PR DESCRIPTION
키워드로 캐스트를 생성해보니까 문제점이 좀 생겨서 수정합니다
- `Sentence` 하나에 여러 개의 영문장이 들어가있음
- 가끔은 원문장-번역문장 매핑 자체가 어긋나면서 IndexError 뜨면서 생성 자체가 안됨

확인해보니까 구분자(@)를 제대로 못 놓고 있는 것 같아요
캐스트 분량 3분 내로 짧을 때도 가끔 그렇고, 5분 이상으로 생성하면 더 자주 이럽니다
캐스트쪽 프롬프트는 안 건드렸는데 왜 갑자기 이러는 지는 모르겠어요 ㅎㅎ 😫

## 변경점
스크립트로 캐스트 생성 시에 `ScriptDivider`를 거치도록 했었는데,
이젠 키워드로 캐스트 생성할 때에도 `ScriptDivider` 거치도록 바꿨습니다.
(캐스트 생성 프롬프트 중에 `문장 끝에 @를 붙이시오`는 뺐어요)

처리시간이 좀 더 길어지긴 하는데 (3분짜리 캐스트 기준 7초 내외)
정확히 동작하는 게 중요하니까 일단 진행시키겠습니다